### PR TITLE
Permit logging from PCS lambda components

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=ERROR,stdout
-log4j.logger.uk.co.bbc.pcs.common.lambda=INFO
+log4j.logger.uk.co.bbc.pcs=INFO
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
With the exception of ERROR statements the current logging configuration prohibits any logging statements made by the Lambda component under test from being logged. By relaxing the INFO package to `uk.co.bbc.pcs` this will allow all PCS Lambdas to log any INFO statements while being invoked. This is useful for debugging during testing and development.