### PR TITLE
Realistic lambda context time remaining.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=6
+version=7
 group=uk.co.bbc.pcs.common
 name=aws-lambda-java-testing-utils

--- a/src/main/java/uk/co/bbc/pcs/common/lambda/mock/MockContextBuilder.java
+++ b/src/main/java/uk/co/bbc/pcs/common/lambda/mock/MockContextBuilder.java
@@ -17,6 +17,7 @@ public class MockContextBuilder {
     private ClientContext clientContext;
     private int remainingTimeInMillis = 0;
     private int memoryLimitInMB = 0;
+    private boolean remainingTimeDoesCountdown;
 
     public MockContextBuilder(String functionName) {
         this.functionName = functionName;
@@ -61,8 +62,13 @@ public class MockContextBuilder {
         return this;
     }
 
+    public MockContextBuilder withRemainingTimeCountdown(boolean remainingTimeDoesCountdown) {
+        this.remainingTimeDoesCountdown = remainingTimeDoesCountdown;
+        return this;
+    }
+
     public MockContext createMockContext() {
         return new MockContext(awsRequestId, logGroupName, logStreamName, functionName, identity,
-                clientContext, remainingTimeInMillis, memoryLimitInMB, logger);
+                clientContext, remainingTimeInMillis, memoryLimitInMB, logger, remainingTimeDoesCountdown);
     }
 }

--- a/src/test/java/uk/co/bbc/pcs/common/lambda/mock/MockContextTest.java
+++ b/src/test/java/uk/co/bbc/pcs/common/lambda/mock/MockContextTest.java
@@ -1,0 +1,38 @@
+package uk.co.bbc.pcs.common.lambda.mock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public class MockContextTest {
+    private static Logger logger = LoggerFactory.getLogger(MockContextTest.class);
+
+    private MockContext underTest;
+    private MockContextBuilder builder;
+
+    @Before
+    public void setUp() throws Exception {
+        builder = new MockContextBuilder("function_name", logger::info);
+    }
+
+    @Test
+    public void getRemainingTimeInMillisShouldDecrement() throws Exception {
+        underTest = builder.withRemainingTimeInMillis(10000).withRemainingTimeCountdown(true).createMockContext();
+        long first = underTest.getRemainingTimeInMillis();
+        Thread.sleep(1001);
+        long second = underTest.getRemainingTimeInMillis();
+        assertTrue(first > second);
+    }
+
+    @Test
+    public void getRemainingTimeInMillisShouldNotDecrementWhenDisabled() throws Exception {
+        underTest = builder.withRemainingTimeInMillis(10000).withRemainingTimeCountdown(false).createMockContext();
+        long first = underTest.getRemainingTimeInMillis();
+        Thread.sleep(1001);
+        long second = underTest.getRemainingTimeInMillis();
+        assertTrue(first == second);
+    }
+}


### PR DESCRIPTION
- Mock context now provides realistic time remaining countdown.
- Defaulted start time to 60s for now, could perhaps be configurable in future.
- Should only affect those that are making use of time remaining, which I assume in no-one as it was returning 0.